### PR TITLE
Added JIRA_IGNORE_INITIAL_CONNECTION_FAILURE option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+  - '2.6'
+  - '2.7'
+  - 'pypy'
+  - '3.3'
+  - '3.4'
+
+install: 'pip install .'
+
+script: 'python setup.py test'

--- a/README.md
+++ b/README.md
@@ -4,10 +4,21 @@ A simple JIRA extension for Flask. Supports basic authentication and OAuth.
 
 *OAuth is currently untested.*
 
+[![Build Status](https://travis-ci.org/Robpol86/Flask-JIRA-Helper.svg?branch=master)]
+(https://travis-ci.org/Robpol86/Flask-JIRA-Helper)
+[![Latest Version](https://pypip.in/version/Flask-JIRA-Helper/badge.png)]
+(https://pypi.python.org/pypi/Flask-JIRA-Helper/)
+[![Downloads](https://pypip.in/download/Flask-JIRA-Helper/badge.png)]
+(https://pypi.python.org/pypi/Flask-JIRA-Helper/)
+[![Download format](https://pypip.in/format/Flask-JIRA-Helper/badge.png)]
+(https://pypi.python.org/pypi/Flask-JIRA-Helper/)
+[![License](https://pypip.in/license/Flask-JIRA-Helper/badge.png)]
+(https://pypi.python.org/pypi/Flask-JIRA-Helper/)
+
 ## Supported Platforms
 
 * OSX and Linux.
-* Python 2.7
+* Python 2.6, 2.7, 3.3, 3.4
 * [Flask](http://flask.pocoo.org/) 0.10.1
 * [JIRA](http://jira-python.readthedocs.org/en/latest/) 0.21
 
@@ -80,8 +91,14 @@ The following config settings are searched for in the Flask application's config
 * `JIRA_SECRET` -- OAuth authentication access token secret.
 * `JIRA_CONSUMER` -- OAuth authentication consumer key.
 * `JIRA_CERT` -- OAuth authentication key certificate data.
+* `JIRA_IGNORE_INITIAL_CONNECTION_FAILURE` -- Ignore ConnectionError during init_app() for testing/development.
 
 ## Changelog
+
+#### 0.2.0
+
+* Added JIRA_IGNORE_INITIAL_CONNECTION_FAILURE option.
+* Added Python 2.6 and 3.x support.
 
 #### 0.1.2
 

--- a/flask_jira.py
+++ b/flask_jira.py
@@ -33,7 +33,7 @@ def read_config(config, prefix):
     # Get all relevant config values from Flask application.
     suffixes = ('SERVER', 'USER', 'PASSWORD', 'TOKEN', 'SECRET', 'CONSUMER', 'CERT')
     config_server, config_user, config_password, config_token, config_secret, config_consumer, config_cert = [
-        config.get('{}_{}'.format(prefix, suffix)) for suffix in suffixes
+        config.get('{0}_{1}'.format(prefix, suffix)) for suffix in suffixes
     ]
     result = dict(options=dict(server=config_server))
     # Gather authentication data.
@@ -133,5 +133,5 @@ class JIRA(client.JIRA):
         try:
             super(JIRA, self).__init__(**args)
         except ConnectionError:
-            if not app.config.get('{}_IGNORE_INITIAL_CONNECTION_FAILURE'.format(config_prefix)):
+            if not app.config.get('{0}_IGNORE_INITIAL_CONNECTION_FAILURE'.format(config_prefix)):
                 raise

--- a/flask_jira.py
+++ b/flask_jira.py
@@ -12,7 +12,7 @@ __license__ = 'MIT'
 __version__ = '0.2.0'
 
 
-def read_config(app, prefix):
+def read_config(config, prefix):
     """Return a jira.client.JIRA.__init__() compatible dictionary from data in the Flask config.
 
     Generate a dictionary compatible with jira.client.JIRA.__init__() keyword arguments from data in the Flask
@@ -20,11 +20,11 @@ def read_config(app, prefix):
     authentication takes precedence.
 
     Usage:
-    config = read_config(app, prefix)
+    config = read_config(app.config, prefix)
     jira = JIRA(**config)
 
     Positional arguments:
-    app -- Flask application instance.
+    config -- Flask application config dictionary.
     prefix -- Prefix used in config key names in the Flask app's configuration.
 
     Returns:
@@ -33,7 +33,7 @@ def read_config(app, prefix):
     # Get all relevant config values from Flask application.
     suffixes = ('SERVER', 'USER', 'PASSWORD', 'TOKEN', 'SECRET', 'CONSUMER', 'CERT')
     config_server, config_user, config_password, config_token, config_secret, config_consumer, config_cert = [
-        app.config.get('{}_{}'.format(prefix, suffix)) for suffix in suffixes
+        config.get('{}_{}'.format(prefix, suffix)) for suffix in suffixes
     ]
     result = dict(options=dict(server=config_server))
     # Gather authentication data.
@@ -127,7 +127,7 @@ class JIRA(client.JIRA):
         app.extensions[config_prefix.lower()] = _JIRAState(self, app)
 
         # Read config.
-        args = read_config(app, config_prefix)
+        args = read_config(app.config, config_prefix)
 
         # Initialize fully.
         try:

--- a/flask_jira.py
+++ b/flask_jira.py
@@ -100,11 +100,11 @@ class JIRA(client.JIRA):
             self.init_app()'s docstring.
         """
         self.original_kill_session = self.kill_session
-        self.kill_session = self.fake_kill_session
+        self.kill_session = self._fake_kill_session
         if app is not None:
             self.init_app(app, config_prefix)
 
-    def fake_kill_session(self):
+    def _fake_kill_session(self):
         """Does nothing. Used to temporary overwrite self.kill_session() in self.__init__().
 
         JIRA calls self.kill_session() even when no session was created.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 # Get the long description and other data from the relevant files
 with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
-with open(os.path.join(here, 'flask_jira.py')) as f:
+with open(os.path.join(here, 'flask_jira.py'), encoding='utf-8') as f:
     lines = [l.strip() for l in f if l.startswith('__')]
 metadata = ast.literal_eval("{'" + ", '".join([l.replace(' = ', "': ") for l in lines]) + '}')
 __author__, __license__, __version__ = [metadata[k] for k in ('__author__', '__license__', '__version__')]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 import ast
-import os
 from codecs import open  # To use a consistent encoding
+import os
 import setuptools
 import setuptools.command.sdist
+from setuptools.command.test import test
+import sys
 
-setuptools.command.sdist.READMES = tuple(list(setuptools.command.sdist.READMES) + ['README.md'])
+
+setattr(setuptools.command.sdist, 'READMES',
+        tuple(list(getattr(setuptools.command.sdist, 'READMES', ())) + ['README.md']))
 here = os.path.abspath(os.path.dirname(__file__))
+
 
 # Get the long description and other data from the relevant files
 with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
@@ -17,6 +22,28 @@ __author__, __license__, __version__ = [metadata[k] for k in ('__author__', '__l
 if not all((__author__, __license__, __version__)):
     raise ValueError('Failed to obtain metadata from module.')
 
+
+class PyTest(test):
+    def finalize_options(self):
+        test.finalize_options(self)
+        setattr(self, 'test_args', ['tests'])
+        setattr(self, 'test_suite', True)
+
+    def run_tests(self):
+        # Import here, cause outside the eggs aren't loaded.
+        pytest = __import__('pytest')
+        err_no = pytest.main(self.test_args)
+        sys.exit(err_no)
+
+
+class PyTestCov(PyTest):
+    def finalize_options(self):
+        test.finalize_options(self)
+        setattr(self, 'test_args', ['--cov', 'flask_jira', 'tests'])
+        setattr(self, 'test_suite', True)
+
+
+# Setup definition.
 setuptools.setup(
     name='Flask-JIRA-Helper',
     version=__version__,
@@ -54,7 +81,10 @@ setuptools.setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Operating System :: POSIX',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
 
     # What does your project relate to?
@@ -68,4 +98,7 @@ setuptools.setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
     install_requires=['Flask', 'jira'],
+
+    tests_require=['pytest'],
+    cmdclass=dict(test=PyTest, testcov=PyTestCov),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
 import ast
+import atexit
 from codecs import open  # To use a consistent encoding
+from distutils.spawn import find_executable
 import os
 import setuptools
 import setuptools.command.sdist
 from setuptools.command.test import test
 import sys
+import subprocess
 
 
 setattr(setuptools.command.sdist, 'READMES',
@@ -41,6 +44,18 @@ class PyTestCov(PyTest):
         test.finalize_options(self)
         setattr(self, 'test_args', ['--cov', 'flask_jira', 'tests'])
         setattr(self, 'test_suite', True)
+
+
+class PyTestCovWeb(PyTest):
+    def finalize_options(self):
+        test.finalize_options(self)
+        setattr(self, 'test_args', ['--cov-report', 'html', '--cov', 'flask_jira', 'tests'])
+        setattr(self, 'test_suite', True)
+
+    def run_tests(self):
+        if find_executable('open'):
+            atexit.register(lambda: subprocess.call(['open', os.path.join(here, 'htmlcov', 'index.html')]))
+        PyTest.run_tests(self)
 
 
 # Setup definition.
@@ -100,5 +115,5 @@ setuptools.setup(
     install_requires=['Flask', 'jira'],
 
     tests_require=['pytest'],
-    cmdclass=dict(test=PyTest, testcov=PyTestCov),
+    cmdclass=dict(test=PyTest, testcov=PyTestCov, testcovweb=PyTestCovWeb),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 import ast
 import atexit
-from codecs import open  # To use a consistent encoding
+from codecs import open
 from distutils.spawn import find_executable
 import os
+import sys
+import subprocess
+
 import setuptools
 import setuptools.command.sdist
 from setuptools.command.test import test
-import sys
-import subprocess
 
 
 setattr(setuptools.command.sdist, 'READMES',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from flask import Flask
+import pytest
+
+
+@pytest.fixture(autouse=True, scope='session')
+def app_context(request):
+    """Initialize the Flask application for tests."""
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    context = app.app_context()
+    context.push()
+    request.addfinalizer(lambda: context.pop())

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -31,3 +31,10 @@ def test_ignore_initial_connection_failure():
     current_app.config['JIRA_IGNORE_INITIAL_CONNECTION_FAILURE'] = True
     jira = JIRA(current_app)
     assert current_app.extensions['jira'].jira == jira
+
+
+def test_multiple():
+    assert 'jira' in current_app.extensions
+
+    with pytest.raises(ValueError):
+        JIRA(current_app)

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,0 +1,33 @@
+from flask import current_app
+from requests import ConnectionError
+import pytest
+
+from flask.ext.jira import JIRA
+
+
+def test_kill_session():
+    jira = JIRA()
+    assert jira.kill_session() == jira
+
+    with pytest.raises(AttributeError):
+        jira.original_kill_session()
+    assert jira.kill_session != jira.original_kill_session
+
+    with pytest.raises(AttributeError):
+        jira.init_app(None)  # This will restore kill_session() and then crash later since app=None.
+
+    with pytest.raises(AttributeError):
+        jira.kill_session()
+    assert jira.kill_session == jira.original_kill_session
+
+
+def test_ignore_initial_connection_failure():
+    current_app.config.update(dict(JIRA_SERVER='http://127.0.0.1', JIRA_USER='userA', JIRA_PASSWORD='passWord'))
+
+    with pytest.raises(ConnectionError):
+        JIRA(current_app)
+
+    current_app.extensions.pop('jira')
+    current_app.config['JIRA_IGNORE_INITIAL_CONNECTION_FAILURE'] = True
+    jira = JIRA(current_app)
+    assert current_app.extensions['jira'].jira == jira

--- a/tests/test_read_config.py
+++ b/tests/test_read_config.py
@@ -1,0 +1,54 @@
+from flask.ext.jira import read_config
+import pytest
+
+
+def test_basic_auth():
+    config = dict(JIRA_SERVER='127.0.0.1', JIRA_USER='userA', JIRA_PASSWORD='passWord')
+    expected = dict(options=dict(server='127.0.0.1'), basic_auth=('userA', 'passWord'))
+    actual = read_config(config, 'JIRA')
+    assert expected == actual
+
+
+def test_oauth():
+    config = dict(JIRA_SERVER='127.0.0.1', JIRA_TOKEN='token', JIRA_SECRET='secret', JIRA_CONSUMER='consumer',
+                  JIRA_CERT='cert')
+    expected = dict(options=dict(server='127.0.0.1'), oauth=dict(access_token='token', access_token_secret='secret',
+                                                                 consumer_key='consumer', key_cert='cert'))
+    actual = read_config(config, 'JIRA')
+    assert expected == actual
+
+
+def test_oauth_priority():
+    config = dict(JIRA_SERVER='127.0.0.1', JIRA_TOKEN='token', JIRA_SECRET='secret', JIRA_CONSUMER='consumer',
+                  JIRA_CERT='cert', JIRA_USER='userA', JIRA_PASSWORD='passWord')
+    expected = dict(options=dict(server='127.0.0.1'), oauth=dict(access_token='token', access_token_secret='secret',
+                                                                 consumer_key='consumer', key_cert='cert'))
+    actual = read_config(config, 'JIRA')
+    assert expected == actual
+
+
+def test_oauth_partial():
+    config = dict(JIRA_SERVER='127.0.0.1', JIRA_TOKEN='token')
+    expected = dict(options=dict(server='127.0.0.1'), oauth=dict(access_token='token', access_token_secret=None,
+                                                                 consumer_key=None, key_cert=None))
+    actual = read_config(config, 'JIRA')
+    assert expected == actual
+
+
+def test_prefix():
+    config = dict(JIRA_SERVER='127.0.0.1', JIRA_USER='userA', JIRA_PASSWORD='passWord', JIRA2_SERVER='127.0.0.2',
+                  JIRA2_USER='userB', JIRA2_PASSWORD='passWord')
+
+    expected = dict(options=dict(server='127.0.0.1'), basic_auth=('userA', 'passWord'))
+    actual = read_config(config, 'JIRA')
+    assert expected == actual
+
+    expected = dict(options=dict(server='127.0.0.2'), basic_auth=('userB', 'passWord'))
+    actual = read_config(config, 'JIRA2')
+    assert expected == actual
+
+
+def test_incomplete():
+    config = dict(JIRA_SERVER='127.0.0.1', JIRA_USER='userA')
+    with pytest.raises(ValueError):
+        read_config(config, 'JIRA')

--- a/tests/test_read_config.py
+++ b/tests/test_read_config.py
@@ -1,5 +1,6 @@
-from flask.ext.jira import read_config
 import pytest
+
+from flask.ext.jira import read_config
 
 
 def test_basic_auth():

--- a/tests/test_read_config.py
+++ b/tests/test_read_config.py
@@ -3,52 +3,54 @@ import pytest
 
 
 def test_basic_auth():
-    config = dict(JIRA_SERVER='127.0.0.1', JIRA_USER='userA', JIRA_PASSWORD='passWord')
-    expected = dict(options=dict(server='127.0.0.1'), basic_auth=('userA', 'passWord'))
+    config = dict(JIRA_SERVER='http://127.0.0.1', JIRA_USER='userA', JIRA_PASSWORD='passWord')
+    expected = dict(options=dict(server='http://127.0.0.1'), basic_auth=('userA', 'passWord'))
     actual = read_config(config, 'JIRA')
     assert expected == actual
 
 
 def test_oauth():
-    config = dict(JIRA_SERVER='127.0.0.1', JIRA_TOKEN='token', JIRA_SECRET='secret', JIRA_CONSUMER='consumer',
+    config = dict(JIRA_SERVER='http://127.0.0.1', JIRA_TOKEN='token', JIRA_SECRET='secret', JIRA_CONSUMER='consumer',
                   JIRA_CERT='cert')
-    expected = dict(options=dict(server='127.0.0.1'), oauth=dict(access_token='token', access_token_secret='secret',
-                                                                 consumer_key='consumer', key_cert='cert'))
+    expected = dict(options=dict(server='http://127.0.0.1'), oauth=dict(access_token='token',
+                                                                        access_token_secret='secret',
+                                                                        consumer_key='consumer', key_cert='cert'))
     actual = read_config(config, 'JIRA')
     assert expected == actual
 
 
 def test_oauth_priority():
-    config = dict(JIRA_SERVER='127.0.0.1', JIRA_TOKEN='token', JIRA_SECRET='secret', JIRA_CONSUMER='consumer',
+    config = dict(JIRA_SERVER='http://127.0.0.1', JIRA_TOKEN='token', JIRA_SECRET='secret', JIRA_CONSUMER='consumer',
                   JIRA_CERT='cert', JIRA_USER='userA', JIRA_PASSWORD='passWord')
-    expected = dict(options=dict(server='127.0.0.1'), oauth=dict(access_token='token', access_token_secret='secret',
-                                                                 consumer_key='consumer', key_cert='cert'))
+    expected = dict(options=dict(server='http://127.0.0.1'), oauth=dict(access_token='token',
+                                                                        access_token_secret='secret',
+                                                                        consumer_key='consumer', key_cert='cert'))
     actual = read_config(config, 'JIRA')
     assert expected == actual
 
 
 def test_oauth_partial():
-    config = dict(JIRA_SERVER='127.0.0.1', JIRA_TOKEN='token')
-    expected = dict(options=dict(server='127.0.0.1'), oauth=dict(access_token='token', access_token_secret=None,
-                                                                 consumer_key=None, key_cert=None))
+    config = dict(JIRA_SERVER='http://127.0.0.1', JIRA_TOKEN='token')
+    expected = dict(options=dict(server='http://127.0.0.1'), oauth=dict(access_token='token', access_token_secret=None,
+                                                                        consumer_key=None, key_cert=None))
     actual = read_config(config, 'JIRA')
     assert expected == actual
 
 
 def test_prefix():
-    config = dict(JIRA_SERVER='127.0.0.1', JIRA_USER='userA', JIRA_PASSWORD='passWord', JIRA2_SERVER='127.0.0.2',
-                  JIRA2_USER='userB', JIRA2_PASSWORD='passWord')
+    config = dict(JIRA_SERVER='http://127.0.0.1', JIRA_USER='userA', JIRA_PASSWORD='passWord',
+                  JIRA2_SERVER='http://127.0.0.2', JIRA2_USER='userB', JIRA2_PASSWORD='passWord')
 
-    expected = dict(options=dict(server='127.0.0.1'), basic_auth=('userA', 'passWord'))
+    expected = dict(options=dict(server='http://127.0.0.1'), basic_auth=('userA', 'passWord'))
     actual = read_config(config, 'JIRA')
     assert expected == actual
 
-    expected = dict(options=dict(server='127.0.0.2'), basic_auth=('userB', 'passWord'))
+    expected = dict(options=dict(server='http://127.0.0.2'), basic_auth=('userB', 'passWord'))
     actual = read_config(config, 'JIRA2')
     assert expected == actual
 
 
 def test_incomplete():
-    config = dict(JIRA_SERVER='127.0.0.1', JIRA_USER='userA')
+    config = dict(JIRA_SERVER='http://127.0.0.1', JIRA_USER='userA')
     with pytest.raises(ValueError):
         read_config(config, 'JIRA')


### PR DESCRIPTION
Option to ignore ConnectionError during init_app() for testing/development. Log when ConnectionError is ignored.
100% test coverage.
Added testcovweb command to setup.py.
Made read_config more testable, it only needs access to app.config dictionary instead of the entire app instance.
Supporting Python 2.6 and 3.x.
