### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A simple JIRA extension for Flask. Supports basic authentication and OAuth.
 (https://travis-ci.org/Robpol86/Flask-JIRA-Helper)
 [![Coverage Status](https://img.shields.io/coveralls/Robpol86/Flask-JIRA-Helper.svg)]
 (https://coveralls.io/r/Robpol86/Flask-JIRA-Helper)
-[![Latest Version](https://pypip.in/version/Flask-JIRA-Helper/badge.png)]
+[![Latest Version](https://img.shields.io/pypi/v/Flask-JIRA-Helper.svg)]
 (https://pypi.python.org/pypi/Flask-JIRA-Helper/)
-[![Downloads](https://pypip.in/download/Flask-JIRA-Helper/badge.png)]
+[![Downloads](https://img.shields.io/pypi/dm/Flask-JIRA-Helper.svg)]
 (https://pypi.python.org/pypi/Flask-JIRA-Helper/)
-[![Download format](https://pypip.in/format/Flask-JIRA-Helper/badge.png)]
+[![Download format](https://img.shields.io/pypi/format/Flask-JIRA-Helper.svg)]
 (https://pypi.python.org/pypi/Flask-JIRA-Helper/)
-[![License](https://pypip.in/license/Flask-JIRA-Helper/badge.png)]
+[![License](https://img.shields.io/pypi/l/Flask-JIRA-Helper.svg)]
 (https://pypi.python.org/pypi/Flask-JIRA-Helper/)
 
 ## Supported Platforms


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-jira-helper))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-jira-helper`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.